### PR TITLE
sec: use strncat() instead of strcat()

### DIFF
--- a/src/libencoding/base64.c
+++ b/src/libencoding/base64.c
@@ -47,7 +47,7 @@ char *base64_encode(char *data, size_t len)
 		 */
 		if (i > 0 && (i / 3 * 4) % 76 == 0)
 		{
-			strcat(result, (char *)"\r\n");
+			strncat(result, (char *)"\r\n", 2);
 			j += 2;
 		}
 		

--- a/src/libsmtp/body.c
+++ b/src/libsmtp/body.c
@@ -36,9 +36,9 @@ static int send_message_with_param(int socket, char *cmd, int cmd_len,
 	memset(msg, 0, cmd_len + msg_len + 2 + 1);
 
 	/* build SMTP message and send it*/
-	strcat(msg, cmd);
+	strncat(msg, cmd, cmd_len);
 	strncat(msg, data, msg_len);
-	strcat(msg, "\r\n");
+	strncat(msg, "\r\n", 2);
 	send(socket, msg, cmd_len + msg_len + 2, 0);
 
 	free(msg);

--- a/src/libsmtp/ehlo.c
+++ b/src/libsmtp/ehlo.c
@@ -103,18 +103,21 @@ __attribute__((pure)) unsigned long parse_smtp_caps(char *r)
 int build_ehlo_msg(char *buffer)
 {
 	char *host = hostname();
-
+	size_t host_len = 0;
+	
 	if (!host)
 	{
 		fprintf(stderr, "Error: can't get local hostname\n");
 		return 0;
 	}
 
+	host_len = strlen(host);
+
 	memset(buffer, 0, 1024);
 
-	strcat(buffer, "EHLO ");
-	strcat(buffer, host);
-	strcat(buffer, "\r\n");
+	strncat(buffer, "EHLO ", 5);
+	strncat(buffer, host, host_len);
+	strncat(buffer, "\r\n", 2);
 
 	free(host);
 	return 1;


### PR DESCRIPTION
http://man.openbsd.org/FreeBSD-11.0/strcat.3#SECURITY_CONSIDERATIONS

Signed-off-by: Alexander Kuleshov <kuleshovmail@gmail.com>